### PR TITLE
Add daily scheduled regression workflow

### DIFF
--- a/.github/workflows/daily-regression.yml
+++ b/.github/workflows/daily-regression.yml
@@ -1,0 +1,27 @@
+name: Daily Regression Tests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r test/requirements.txt
+
+      - name: Run regression tests
+        run: pytest test/test_regression.py -v


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the regression test suite on a daily schedule
- install the regression test dependencies before executing the targeted pytest command

## Testing
- not run (workflow configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68df6c4c16488323a4cdad9325bb04e3