### PR TITLE
Add macOS run to daily regression workflow

### DIFF
--- a/.github/workflows/daily-regression.yml
+++ b/.github/workflows/daily-regression.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   regression:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- run the daily regression job on both Ubuntu and macOS runners via a matrix strategy

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68df6e21d04c8323bf2b186b76c6c4eb