### PR TITLE
Fix regression workflow paths

### DIFF
--- a/.github/workflows/daily-regression.yml
+++ b/.github/workflows/daily-regression.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r test/requirements.txt
+          pip install -r tests/requirements.txt
 
       - name: Run regression tests
-        run: pytest test/test_regression.py -v
+        run: pytest tests/test_regression.py -v

--- a/tests/TEST_README.md
+++ b/tests/TEST_README.md
@@ -15,14 +15,14 @@ The regression test uses the `../data/datasets/lorenz_small.txt` dataset to veri
 First, install the required dependencies:
 
 ```bash
-pip install -r test/requirements.txt
+pip install -r tests/requirements.txt
 ```
 
 ## Running the Test
 
 ### Option 1: Using pytest from TLR root directory
 ```bash
-pytest test/test_regression.py -v
+pytest tests/test_regression.py -v
 ```
 
 ### Option 2: From test directory
@@ -38,7 +38,7 @@ pytest test_regression.py -v
 
 ### Option 4: Run specific test
 ```bash
-pytest test/test_regression.py::test_data_loading -v
+pytest tests/test_regression.py::test_data_loading -v
 ```
 
 ## Test Details


### PR DESCRIPTION
## Summary
- correct the regression workflow to install dependencies from the existing `tests` directory
- update the regression test documentation to reference the proper `tests` paths

## Testing
- ⚠️ `pip install -r tests/requirements.txt` *(fails in this environment: ProxyError while downloading xarray)*

------
https://chatgpt.com/codex/tasks/task_e_68df73195af483239d28f98a0dd1af2f